### PR TITLE
not yet compatible with aiohttp2.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ def read_version():
             raise RuntimeError(msg)
 
 
-install_requires = ['aiohttp>=0.14']
+install_requires = ['aiohttp>=0.14,<2.0']
 
 
 setup(name='aiohttp-sse',


### PR DESCRIPTION
@jettify let's cut a release with this one.
Then we can decide to drop support for aiohttp<2.0 with a major version bump