### PR TITLE
Clean up the connection when someone leaves

### DIFF
--- a/examples/chat.py
+++ b/examples/chat.py
@@ -97,10 +97,14 @@ async def subscribe(request):
         queue = asyncio.Queue()
         print('Someone joined.')
         request.app['channels'].add(queue)
-        while True:
-            payload = await queue.get()
-            response.send(payload)
-            queue.task_done()
+        try:
+            while not response.task.done():
+                payload = await queue.get()
+                response.send(payload)
+                queue.task_done()
+        finally:
+            request.app['channels'].remove(queue)
+            print('Someone left.')
     return response
 
 


### PR DESCRIPTION
Rather than using an infinite loop we switch to checking if the response
task is done. This will happen if the client disconnects. When that
happens we can exit the subscribe loop and free up the resources
associated with the queue for that client.