### PR TITLE
New API #28

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -41,8 +41,7 @@ Example
 
     async def hello(request):
         loop = request.app.loop
-        resp = await sse_response(request)
-        async with resp:
+        async with sse_response(request) as resp:
             for i in range(0, 100):
                 print('foo')
                 await asyncio.sleep(1, loop=loop)

--- a/aiohttp_sse/helpers.py
+++ b/aiohttp_sse/helpers.py
@@ -1,0 +1,44 @@
+from collections.abc import Coroutine
+
+
+class _ContextManager(Coroutine):
+
+    __slots__ = ('_coro', '_obj')
+
+    def __init__(self, coro):
+        self._coro = coro
+        self._obj = None
+
+    def send(self, arg):
+        return self._coro.send(arg)  # pragma: no cover
+
+    def throw(self, arg):
+        return self._coro.throw(arg)  # pragma: no cover
+
+    def close(self):
+        return self._coro.close()  # pragma: no cover
+
+    @property
+    def gi_frame(self):
+        return self._coro.gi_frame  # pragma: no cover
+
+    @property
+    def gi_running(self):
+        return self._coro.gi_running  # pragma: no cover
+
+    @property
+    def gi_code(self):
+        return self._coro.gi_code  # pragma: no cover
+
+    def __next__(self):
+        return self.send(None)  # pragma: no cover
+
+    def __await__(self):
+        return self._coro.__await__()
+
+    async def __aenter__(self):
+        self._obj = await self._coro
+        return await self._obj.__aenter__()
+
+    async def __aexit__(self, exc_type, exc, tb):
+        await self._obj.__aexit__(exc_type, exc, tb)

--- a/examples/chat.py
+++ b/examples/chat.py
@@ -91,8 +91,7 @@ async def message(request):
 
 
 async def subscribe(request):
-    response = await sse_response(request)
-    async with response:
+    async with sse_response(request) as response:
         app = request.app
         queue = asyncio.Queue()
         print('Someone joined.')

--- a/examples/simple.py
+++ b/examples/simple.py
@@ -5,8 +5,7 @@ from aiohttp_sse import sse_response
 
 
 async def hello(request):
-    resp = await sse_response(request)
-    async with resp:
+    async with sse_response(request) as resp:
         for i in range(0, 100):
             print('foo')
             await asyncio.sleep(1)

--- a/tests/test_sse.py
+++ b/tests/test_sse.py
@@ -211,8 +211,8 @@ async def test_ping(loop, unused_tcp_port, session):
 async def test_context_manager(loop, unused_tcp_port, session):
 
     async def func(request):
-        sse = await sse_response(request, headers={'X-SSE': 'aiohttp_sse'})
-        async with sse:
+        h = {'X-SSE': 'aiohttp_sse'}
+        async with sse_response(request, headers=h) as sse:
             sse.send('foo')
             sse.send('foo', event='bar')
             sse.send('foo', event='bar', id='xyz')


### PR DESCRIPTION
For context see https://github.com/aio-libs/aiohttp-sse/issues/28

Old way works as well:
```
resp = await sse_response(request)
async with resp:
    resp.send('foo {}'.format(i))
```