### PR TITLE
Add support multi-line data, various stream-separators (LF, CR, CR+LF), custom response classes

### DIFF
--- a/aiohttp_sse/__init__.py
+++ b/aiohttp_sse/__init__.py
@@ -9,7 +9,7 @@ from aiohttp.web import HTTPMethodNotAllowed
 from .helpers import _ContextManager
 
 
-__version__ = '2.2.0'
+__version__ = '2.2.1'
 __all__ = ['EventSourceResponse', 'sse_response']
 
 
@@ -161,9 +161,12 @@ class EventSourceResponse(StreamResponse):
         return
 
 
-def sse_response(request, *, status=200, reason=None, headers=None, sep=None):
-    sse = EventSourceResponse(status=status,
-                              reason=reason,
-                              headers=headers,
-                              sep=sep)
+def sse_response(request, *, status=200, reason=None, headers=None, sep=None,
+                 response_cls=EventSourceResponse):
+    if not issubclass(response_cls, EventSourceResponse):
+        raise TypeError(
+            'response_cls must be subclass of '
+            'aiohttp_sse.EventSourceResponse, got {}'.format(response_cls))
+
+    sse = response_cls(status=status, reason=reason, headers=headers, sep=sep)
     return _ContextManager(sse._prepare(request))

--- a/aiohttp_sse/__init__.py
+++ b/aiohttp_sse/__init__.py
@@ -9,7 +9,7 @@ from aiohttp.web import HTTPMethodNotAllowed
 from .helpers import _ContextManager
 
 
-__version__ = '2.2.1'
+__version__ = '2.2.0'
 __all__ = ['EventSourceResponse', 'sse_response']
 
 
@@ -84,11 +84,11 @@ class EventSourceResponse(StreamResponse):
         """
         buffer = io.StringIO()
         if id is not None:
-            buffer.write('id: {}'.format(self.LINE_SEP_EXPR.sub('', id)))
+            buffer.write(self.LINE_SEP_EXPR.sub('', 'id: {}'.format(id)))
             buffer.write(self._sep)
 
         if event is not None:
-            buffer.write('event: {}'.format(self.LINE_SEP_EXPR.sub('', event)))
+            buffer.write(self.LINE_SEP_EXPR.sub('', 'event: {}'.format(event)))
             buffer.write(self._sep)
 
         for chunk in self.LINE_SEP_EXPR.split(data):

--- a/examples/graceful_shutdown.py
+++ b/examples/graceful_shutdown.py
@@ -1,0 +1,103 @@
+import asyncio
+import json
+import weakref
+from contextlib import suppress
+from datetime import datetime
+from functools import partial
+
+from aiohttp import web
+
+from aiohttp_sse import EventSourceResponse, sse_response
+
+
+class SSEResponse(EventSourceResponse):
+    @property
+    def last_event_id(self):
+        return self._req.headers.get("Last-Event-Id")
+
+    async def send_json(self, data, id=None, event=None, retry=None,
+                        json_dumps=partial(json.dumps, indent=2)):
+        await self.send(json_dumps(data), id=id, event=event, retry=retry)
+
+
+async def worker(app):
+    while True:
+        now = datetime.now()
+        delay = asyncio.ensure_future(asyncio.sleep(1, loop=app.loop))  # Fire
+
+        fs = []
+        for stream in app['streams']:
+            data = {'time': 'Server Time : {}'.format(now),
+                    'last_event_id': stream.last_event_id}
+            fs.append(stream.send_json(data, id=now.timestamp()))
+
+        # Run in parallel
+        await asyncio.gather(*fs, loop=app.loop)
+
+        # Sleep 1s - n
+        await delay
+
+
+async def on_startup(app):
+    app['streams'] = weakref.WeakSet()
+    app['worker'] = app.loop.create_task(worker(app))
+
+
+async def clean_up(app):
+    app['worker'].cancel()
+    with suppress(asyncio.CancelledError):
+        await app['worker']
+
+
+async def on_shutdown(app):
+    waiters = []
+    for stream in app['streams']:
+        stream.stop_streaming()
+        waiters.append(stream.wait())
+
+    await asyncio.gather(*waiters, loop=app.loop)
+    app['streams'].clear()
+
+
+async def hello(request):
+    stream = await sse_response(request, response_cls=SSEResponse)
+    request.app['streams'].add(stream)
+    try:
+        await stream.wait()
+    finally:
+        request.app['streams'].discard(stream)
+    return stream
+
+
+async def index(request):
+    d = """
+        <html>
+        <head>
+            <script type="text/javascript"
+                src="http://code.jquery.com/jquery.min.js"></script>
+            <script type="text/javascript">
+            var evtSource = new EventSource("/hello");
+            evtSource.onmessage = function(e) {
+              $('#response').html(e.data);
+            }
+            </script>
+        </head>
+        <body>
+            <h1>Response from server:</h1>
+            <pre id="response"></pre>
+        </body>
+    </html>
+    """
+    return web.Response(text=d, content_type='text/html')
+
+
+if __name__ == '__main__':
+    app = web.Application()
+
+    app.on_startup.append(on_startup)
+    app.on_shutdown.append(on_shutdown)
+    app.on_cleanup.append(clean_up)
+
+    app.router.add_route('GET', '/hello', hello)
+    app.router.add_route('GET', '/index', index)
+    web.run_app(app, host='127.0.0.1', port=8080)

--- a/examples/simple.py
+++ b/examples/simple.py
@@ -1,14 +1,18 @@
 import asyncio
-from aiohttp import web
-from aiohttp.web import Application, Response
-from aiohttp_sse import sse_response
+import json
 from datetime import datetime
+
+from aiohttp import web
+
+from aiohttp_sse import sse_response
+
 
 async def hello(request):
     loop = request.app.loop
     async with sse_response(request) as resp:
         while True:
-            data = 'Server Time : {}'.format(datetime.now())
+            time_dict = {'time': 'Server Time : {}'.format(datetime.now())}
+            data = json.dumps(time_dict, indent=2)
             print(data)
             await resp.send(data)
             await asyncio.sleep(1, loop=loop)
@@ -24,21 +28,21 @@ async def index(request):
             <script type="text/javascript">
             var evtSource = new EventSource("/hello");
             evtSource.onmessage = function(e) {
-             $('#response').html(e.data);
+              $('#response').html(e.data);
             }
-
             </script>
         </head>
         <body>
             <h1>Response from server:</h1>
-            <div id="response"></div>
+            <pre id="response"></pre>
         </body>
     </html>
     """
-    return Response(text=d, content_type='text/html')
+    return web.Response(text=d, content_type='text/html')
 
 
-app = web.Application()
-app.router.add_route('GET', '/hello', hello)
-app.router.add_route('GET', '/index', index)
-web.run_app(app, host='127.0.0.1', port=8080)
+if __name__ == '__main__':
+    app = web.Application()
+    app.router.add_route('GET', '/hello', hello)
+    app.router.add_route('GET', '/index', index)
+    web.run_app(app, host='127.0.0.1', port=8080)


### PR DESCRIPTION
Bump version to 2.2.0

Add support:
- multi-line data
- various stream-separators (LF, CR, CR+LF)
- custom response classes

Handle:
- connection lost event

Add graceful shutdown example