### PR TITLE
Python 3.10 Support / Fix for #314

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,7 @@ CHANGES
 2.1 (Undefined)
 ---------------
 * 163.misc Add explicit support for python3.7
+* 314.bugfix Added Python 3.10 support
 
 2.0 (2018-02-19)
 ----------------

--- a/aiohttp_sse/__init__.py
+++ b/aiohttp_sse/__init__.py
@@ -155,7 +155,7 @@ class EventSourceResponse(StreamResponse):
         # starts with ":" colon ignored by a browser and could be used
         # as ping message.
         while True:
-            await asyncio.sleep(self._ping_interval, loop=self._loop)
+            await asyncio.sleep(self._ping_interval)
             await self.write(': ping{0}{0}'.format(self._sep).encode('utf-8'))
 
     async def __aenter__(self):


### PR DESCRIPTION
## What do these changes do?

Got rid of deprecated `loop=` argument for `asyncio.sleep()`, which supports Python 3.10 and fixes https://github.com/aio-libs/aiohttp-sse/issues/314.

## Are there changes in behavior for the user?

None

## Related issue number

[<!-- Are there any issues opened that will be resolved by merging this change? -->](https://github.com/aio-libs/aiohttp-sse/issues/314)

## Checklist

- [x] I think the code is well written
- [ ] ~~Unit tests for the changes exist~~ &mdash; Existing unit tests pass.
- [ ] ~~Documentation reflects the changes~~ &mdash; Unnecessary. 
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
