### PR TITLE
Add public state for SSE

### DIFF
--- a/CHANGES/391.feature
+++ b/CHANGES/391.feature
@@ -1,0 +1,1 @@
+Added the ability to publicly access the connection status via `.is_connected()` method.

--- a/aiohttp_sse/__init__.py
+++ b/aiohttp_sse/__init__.py
@@ -44,6 +44,11 @@ class EventSourceResponse(StreamResponse):
         self._ping_task = None
         self._sep = sep if sep is not None else self.DEFAULT_SEPARATOR
 
+    @property
+    def is_connected(self):
+        """Check connection is prepared and ping task is not done."""
+        return self.prepared and not self._ping_task.done()
+
     async def _prepare(self, request):
         await self.prepare(request)
         return self

--- a/aiohttp_sse/__init__.py
+++ b/aiohttp_sse/__init__.py
@@ -44,8 +44,7 @@ class EventSourceResponse(StreamResponse):
         self._ping_task = None
         self._sep = sep if sep is not None else self.DEFAULT_SEPARATOR
 
-    @property
-    def is_connected(self):
+    def is_connected(self) -> bool:
         """Check connection is prepared and ping task is not done."""
         return self.prepared and not self._ping_task.done()
 


### PR DESCRIPTION
## What do these changes do?

Since https://github.com/aio-libs/aiohttp/issues/3105 is abandoned for many years, I think we can make simple way to check SSE state (based on ping). After 3105 problem become closed, it will be possible to rely on the new logic in this method, saving the contract.

## Are there changes in behaviour for the user?

Added the ability to publicly access the connection status via `.is_connected()` method.

## Related issue number

Closes #391

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
