### PR TITLE
Add support for all http-methods

### DIFF
--- a/aiohttp_sse/__init__.py
+++ b/aiohttp_sse/__init__.py
@@ -4,7 +4,7 @@ import io
 import re
 from typing import Optional
 
-from aiohttp.web import HTTPMethodNotAllowed, StreamResponse
+from aiohttp.web import StreamResponse
 
 from .helpers import _ContextManager
 
@@ -59,9 +59,6 @@ class EventSourceResponse(StreamResponse):
 
         :param request: regular aiohttp.web.Request.
         """
-        if request.method != "GET":
-            raise HTTPMethodNotAllowed(request.method, ["GET"])
-
         if not self.prepared:
             writer = await super().prepare(request)
             self._ping_task = asyncio.create_task(self._ping())

--- a/tests/test_sse.py
+++ b/tests/test_sse.py
@@ -551,7 +551,7 @@ class TestLastEventId:
 
 @pytest.mark.parametrize(
     "http_method",
-    ["GET", "POST", "PUT", "DELETE", "PATCH"],
+    ("GET", "POST", "PUT", "DELETE", "PATCH"),
 )
 async def test_http_methods(
     unused_tcp_port: int,
@@ -571,7 +571,7 @@ async def test_http_methods(
     url = f"http://127.0.0.1:{unused_tcp_port}/"
 
     resp = await session.request(http_method, url)
-    assert 200 == resp.status
+    assert resp.status == 200
 
     # check streamed data
     streamed_data = await resp.text()

--- a/tests/test_sse.py
+++ b/tests/test_sse.py
@@ -69,12 +69,6 @@ async def test_func(unused_tcp_port, with_sse_response, session):
         "id: xyz\r\nevent: bar\r\ndata: foo\r\nretry: 1\r\n\r\n"
     )
     assert streamed_data == expected
-
-    # check that EventSourceResponse object works only
-    # with GET method
-    resp = await session.request("POST", url)
-    assert 405 == resp.status
-    resp.close()
     await runner.cleanup()
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Add support for all http-methods.

## Are there changes in behavior for the user?

Programmers will decide for themselves which http-method use to establish SSE-connection

## Related issue number

Fixes #414 

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
