### PR TITLE
Add timeout support

### DIFF
--- a/aiohttp_sse/__init__.py
+++ b/aiohttp_sse/__init__.py
@@ -39,6 +39,7 @@ class EventSourceResponse(StreamResponse):
         reason: Optional[str] = None,
         headers: Optional[Mapping[str, str]] = None,
         sep: Optional[str] = None,
+        timeout: Optional[float] = None,
     ):
         super().__init__(status=status, reason=reason)
 
@@ -54,6 +55,7 @@ class EventSourceResponse(StreamResponse):
         self._ping_interval: float = self.DEFAULT_PING_INTERVAL
         self._ping_task: Optional[asyncio.Task[None]] = None
         self._sep = sep if sep is not None else self.DEFAULT_SEPARATOR
+        self._timeout = timeout
 
     def is_connected(self) -> bool:
         """Check connection is prepared and ping task is not done."""
@@ -130,10 +132,16 @@ class EventSourceResponse(StreamResponse):
 
         buffer.write(self._sep)
         try:
-            await self.write(buffer.getvalue().encode("utf-8"))
+            await asyncio.wait_for(  # TODO(PY311): Use asyncio.timeout
+                self.write(buffer.getvalue().encode("utf-8")),
+                timeout=self._timeout,
+            )
         except ConnectionResetError:
             self.stop_streaming()
             raise
+        except asyncio.TimeoutError:
+            self.stop_streaming()
+            raise TimeoutError
 
     async def wait(self) -> None:
         """EventSourceResponse object is used for streaming data to the client,
@@ -202,8 +210,16 @@ class EventSourceResponse(StreamResponse):
         while True:
             await asyncio.sleep(self._ping_interval)
             try:
-                await self.write(message)
-            except (ConnectionResetError, RuntimeError):
+                await asyncio.wait_for(  # TODO(PY311): Use asyncio.timeout
+                    self.write(message),
+                    timeout=self._timeout,
+                )
+            except (
+                ConnectionResetError,
+                RuntimeError,
+                TimeoutError,
+                asyncio.TimeoutError,
+            ):
                 # RuntimeError - on writing after EOF
                 break
 
@@ -256,6 +272,7 @@ def sse_response(
     headers: Optional[Mapping[str, str]] = None,
     sep: Optional[str] = None,
     response_cls: Type[EventSourceResponse] = EventSourceResponse,
+    timeout: Optional[float] = None,
 ) -> Any:
     if not issubclass(response_cls, EventSourceResponse):
         raise TypeError(
@@ -263,5 +280,11 @@ def sse_response(
             "aiohttp_sse.EventSourceResponse, got {}".format(response_cls)
         )
 
-    sse = response_cls(status=status, reason=reason, headers=headers, sep=sep)
+    sse = response_cls(
+        status=status,
+        reason=reason,
+        headers=headers,
+        sep=sep,
+        timeout=timeout,
+    )
     return _ContextManager(sse._prepare(request))

--- a/tests/test_sse.py
+++ b/tests/test_sse.py
@@ -591,7 +591,7 @@ async def test_with_timeout(
                 timeout_raised = True
                 raise
 
-        return sse
+        return sse  # pragma: no cover
 
     app = web.Application()
     app.router.add_route("GET", "/", handler)
@@ -600,6 +600,6 @@ async def test_with_timeout(
     async with client.get("/") as resp:
         assert resp.status == 200
         await asyncio.sleep(0.5)
-        assert resp.connection.closed is bool(timeout)
+        assert resp.connection and resp.connection.closed is bool(timeout)
 
     assert timeout_raised is bool(timeout)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Provides a way to work around issue https://github.com/sysid/sse-starlette/issues/89

## Are there changes in behavior for the user?

Added the ability to set a timeout for interaction with a connection.

For example, if a hung connection does not read ping messages, then after a while we can automatically disconnect it to free up resources.

## Related issue number

https://github.com/sysid/sse-starlette/issues/89

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
