### PR TITLE
README: add missing import json in example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -33,6 +33,7 @@ Example
 .. code:: python
 
     import asyncio
+    import json 
     from datetime import datetime
 
     from aiohttp import web


### PR DESCRIPTION
The example uses json.dumps but doesn’t import json. This adds the import so users can run it as is.

<!-- Thank you for your contribution! -->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- Remember to prefix with 'Fixes' if it should close the issue (e.g. 'Fixes #123'). -->

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
